### PR TITLE
feat: Add VIES VAT lookup integration with caching

### DIFF
--- a/app/Domain/ViesLookup/DTOs/ViesLookupResultDTO.php
+++ b/app/Domain/ViesLookup/DTOs/ViesLookupResultDTO.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Domain\ViesLookup\DTOs;
+
+class ViesLookupResultDTO
+{
+    public function __construct(
+        public readonly string $countryCode,
+        public readonly string $vatNumber,
+        public readonly bool $valid,
+        public readonly ?string $name,
+        public readonly ?string $address,
+    ) {}
+
+    public static function fromApiResponse(array $data): self
+    {
+        return new self(
+            countryCode: $data['countryCode'] ?? '',
+            vatNumber: $data['vatNumber'] ?? '',
+            valid: (bool) ($data['valid'] ?? false),
+            name: $data['name'] ?? null,
+            address: $data['address'] ?? null,
+        );
+    }
+}

--- a/app/Domain/ViesLookup/Exceptions/ViesLookupException.php
+++ b/app/Domain/ViesLookup/Exceptions/ViesLookupException.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace App\Domain\ViesLookup\Exceptions;
+
+use Exception;
+
+class ViesLookupException extends Exception
+{
+    / /
+}

--- a/app/Domain/ViesLookup/Integrations/Requests/CheckVatRequest.php
+++ b/app/Domain/ViesLookup/Integrations/Requests/CheckVatRequest.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace App\Domain\ViesLookup\Integrations\Requests;
+
+use Saloon\Http\Request;
+use Saloon\Enums\Method;
+
+class CheckVatRequest extends Request
+{
+    protected Method $method = Method::POST;
+
+    public function __construct(
+        protected string $countryCode,
+        protected string $vatNumber,
+    ) {}
+
+    public function resolveEndpoint(): string
+    {
+        return ''; // Base URL is enough for SOAP service
+    }
+
+    public function defaultBody(): array
+    {
+        return [
+            'countryCode' => $this->countryCode,
+            'vatNumber' => $this->vatNumber,
+        ];
+    }
+
+    public function defaultHeaders(): array
+    {
+        return [
+            'Content-Type' => 'text/xml; charset=utf-8',
+            'SOAPAction' => '',
+        ];
+    }
+
+    protected function defaultBodyAsString(): string
+    {
+        return <<<XML
+<?xml version="1.0" encoding="UTF-8"?>
+<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/" xmlns:tns="urn:ec.europa.eu:taxud:vies:services:checkVat:types">
+  <soap:Body>
+    <tns:checkVat>
+      <tns:countryCode>{$this->countryCode}</tns:countryCode>
+      <tns:vatNumber>{$this->vatNumber}</tns:vatNumber>
+    </tns:checkVat>
+  </soap:Body>
+</soap:Envelope>
+XML;
+    }
+}

--- a/app/Domain/ViesLookup/Integrations/ViesConnector.php
+++ b/app/Domain/ViesLookup/Integrations/ViesConnector.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace App\Domain\ViesLookup\Integrations;
+
+use Saloon\Http\Connector;
+
+class ViesConnector extends Connector
+{
+    public function resolveBaseUrl(): string
+    {
+        return 'https://ec.europa.eu/taxation_customs/vies/services/checkVatService'; // This is SOAP
+     }
+}

--- a/app/Domain/ViesLookup/Services/ViesLookupService.php
+++ b/app/Domain/ViesLookup/Services/ViesLookupService.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace App\Domain\ViesLookup\Services;
+
+use App\Domain\ViesLookup\DTOs\ViesLookupResultDTO;
+use App\Domain\ViesLookup\Exceptions\ViesLookupException;
+use App\Domain\ViesLookup\Integrations\ViesConnector;
+use App\Domain\ViesLookup\Integrations\Requests\CheckVatRequest;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Log;
+
+class ViesLookupService
+{
+    protected const DEFAULT_CACHE_HOURS = 12;
+
+    protected ViesConnector $connector;
+
+    public function __construct()
+    {
+        $this->connector = new ViesConnector();
+    }
+
+    public function findByVat(string $countryCode, string $vatNumber): ?ViesLookupResultDTO
+    {
+        $countryCode = strtoupper(trim($countryCode));
+        $vatNumber = preg_replace('/[^0-9A-Za-z]/', '', $vatNumber);
+
+        $cacheKey = "vies_lookup_{$countryCode}_{$vatNumber}";
+        $cacheTtl = $this->getCacheExpiration();
+
+        return Cache::remember($cacheKey, $cacheTtl, function () use ($countryCode, $vatNumber) {
+            try {
+                $request = new CheckVatRequest($countryCode, $vatNumber);
+                $response = $this->connector->send($request);
+
+                if ($response->successful()) {
+                    $xml = simplexml_load_string($response->body());
+
+                    if ($xml === false) {
+                        throw new ViesLookupException('Invalid VIES XML response.');
+                    }
+
+                    $result = json_decode(json_encode($xml), true);
+
+                    return ViesLookupResultDTO::fromApiResponse([
+                        'countryCode' => $result['soap:Body']['checkVatResponse']['countryCode'] ?? '',
+                        'vatNumber' => $result['soap:Body']['checkVatResponse']['vatNumber'] ?? '',
+                        'valid' => $result['soap:Body']['checkVatResponse']['valid'] ?? false,
+                        'name' => $result['soap:Body']['checkVatResponse']['name'] ?? null,
+                        'address' => $result['soap:Body']['checkVatResponse']['address'] ?? null,
+                    ]);
+                }
+
+                throw new ViesLookupException('Unsuccessful VIES API response.');
+            } catch (\Throwable $e) {
+                Log::error('ViesLookupService error: ' . $e->getMessage(), [
+                    'countryCode' => $countryCode,
+                    'vatNumber' => $vatNumber,
+                ]);
+
+                throw new ViesLookupException('Failed to lookup VAT number.', 0, $e);
+            }
+        });
+    }
+
+    protected function getCacheExpiration(): \DateTimeInterface|\DateInterval|int
+    {
+        $cacheMode = config('vies_lookup.cache_mode', 'hours');
+
+        if ($cacheMode === 'week') {
+            return now()->next('Sunday')->startOfDay();
+        }
+
+        $hours = (int) config('vies_lookup.cache_hours', self::DEFAULT_CACHE_HOURS);
+
+        return now()->addHours($hours);
+    }
+}

--- a/config/vies_lookup.php
+++ b/config/vies_lookup.php
@@ -1,0 +1,6 @@
+<?php
+
+return [
+    'cache_hours' => env('VIES_LOOKUP_CACHE_HOURS', 12),
+    'cache_mode' => env('VIES_LOOKUP_CACHE_MODE', 'hours'), // 'hours' or 'week'
+];


### PR DESCRIPTION
- Implemented ViesLookupService using Saloon
- Added ViesConnector and CheckVatRequest for SOAP requests
- Created ViesLookupResultDTO and ViesLookupException
- Configurable caching (hours or until next week) via config/vies_lookup.php
- Logging and error handling included